### PR TITLE
Add Vite React project for HA automation diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# ha-automation-visualizer
+# HA Automation Visualizer
+
+Dieses Projekt visualisiert Home-Assistant-Automationen als Flussdiagramm.
+Die YAML-Dateien liegen im Ordner `public/automations/` und werden
+clientseitig geladen und mit [Mermaid](https://mermaid.js.org/) dargestellt.
+
+## Entwicklung
+
+```bash
+npm install
+npm run dev
+```
+
+## Deployment auf GitHub Pages
+
+1. Stelle sicher, dass in `vite.config.ts` der Base-Pfad korrekt ist:
+   ```ts
+   export default defineConfig({
+     base: '/ha-automation-visualizer/',
+   })
+   ```
+2. Baue das Projekt und veröffentliche es auf dem Branch `gh-pages`:
+   ```bash
+   npm run deploy
+   ```
+
+GitHub Pages kann anschließend aus dem Branch `gh-pages` die statische Seite
+hosten.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HA Automation Visualizer</title>
+  </head>
+  <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "ha-automation-visualizer",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "deploy": "npm run build && gh-pages -d dist -b gh-pages"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "js-yaml": "^4.1.0",
+    "mermaid": "^10.2.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "gh-pages": "^6.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/automations/automations.json
+++ b/public/automations/automations.json
@@ -1,0 +1,7 @@
+[
+  {
+    "file": "licht_abends.yaml",
+    "title": "Licht Abends",
+    "description": "Schaltet das Licht bei Sonnenuntergang ein"
+  }
+]

--- a/public/automations/licht_abends.yaml
+++ b/public/automations/licht_abends.yaml
@@ -1,0 +1,10 @@
+alias: "Licht abends einschalten"
+description: "Schaltet das Licht bei Sonnenuntergang ein"
+trigger:
+  - platform: sun
+    event: sunset
+condition: []
+action:
+  - service: light.turn_on
+    target:
+      entity_id: light.wohnzimmer

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,3 @@
+body {
+  @apply bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import AutomationList, { AutomationInfo } from './components/AutomationList';
+import AutomationViewer from './components/AutomationViewer';
+import './App.css';
+
+export default function App() {
+  const [selected, setSelected] = useState<AutomationInfo | null>(null);
+
+  return (
+    <div className="container mx-auto p-4">
+      {!selected ? (
+        <AutomationList onSelect={setSelected} />
+      ) : (
+        <AutomationViewer info={selected} onBack={() => setSelected(null)} />
+      )}
+    </div>
+  );
+}

--- a/src/components/AutomationList.tsx
+++ b/src/components/AutomationList.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+export interface AutomationInfo {
+  file: string;
+  title: string;
+  description?: string;
+}
+
+interface Props {
+  onSelect: (info: AutomationInfo) => void;
+}
+
+export default function AutomationList({ onSelect }: Props) {
+  const [list, setList] = useState<AutomationInfo[]>([]);
+
+  useEffect(() => {
+    fetch('automations/automations.json')
+      .then((res) => res.json())
+      .then((data) => setList(data));
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Automationen</h1>
+      <ul className="space-y-2">
+        {list.map((item) => (
+          <li
+            key={item.file}
+            className="p-4 border rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
+            onClick={() => onSelect(item)}
+          >
+            <h2 className="text-xl font-semibold">{item.title}</h2>
+            {item.description && <p className="text-sm opacity-80">{item.description}</p>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/AutomationViewer.tsx
+++ b/src/components/AutomationViewer.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import DiagramRenderer from './DiagramRenderer';
+import { AutomationInfo } from './AutomationList';
+import { automationToMermaid, parseAutomation } from '../utils/parseYaml';
+
+interface Props {
+  info: AutomationInfo;
+  onBack: () => void;
+}
+
+export default function AutomationViewer({ info, onBack }: Props) {
+  const [yamlText, setYamlText] = useState('');
+  const [showYaml, setShowYaml] = useState(false);
+
+  useEffect(() => {
+    fetch(`automations/${info.file}`)
+      .then((res) => res.text())
+      .then((text) => setYamlText(text));
+  }, [info.file]);
+
+  const automation = parseAutomation(yamlText);
+  const mermaidDef = automationToMermaid(automation);
+
+  return (
+    <div className="space-y-4">
+      <button onClick={onBack} className="underline">Zurück</button>
+      <h2 className="text-xl font-bold">{info.title}</h2>
+      <DiagramRenderer definition={mermaidDef} />
+      <button onClick={() => setShowYaml((v) => !v)} className="underline">
+        YAML {showYaml ? 'ausblenden' : 'anzeigen'}
+      </button>
+      {showYaml && (
+        <pre className="bg-gray-200 dark:bg-gray-800 p-4 overflow-auto">
+          <code>{yamlText}</code>
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/src/components/DiagramRenderer.tsx
+++ b/src/components/DiagramRenderer.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+import mermaid from 'mermaid';
+
+interface Props {
+  definition: string;
+}
+
+export default function DiagramRenderer({ definition }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
+    mermaid.render('diagram', definition).then(({ svg }) => {
+      if (ref.current) ref.current.innerHTML = svg;
+    });
+  }, [definition]);
+
+  return <div ref={ref} className="mermaid" />;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.mermaid .trigger rect {
+  fill: #86efac;
+}
+.mermaid .condition rect {
+  fill: #facc15;
+}
+.mermaid .action rect {
+  fill: #93c5fd;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/utils/parseYaml.ts
+++ b/src/utils/parseYaml.ts
@@ -1,0 +1,41 @@
+import yaml from 'js-yaml';
+
+export interface Automation {
+  alias?: string;
+  description?: string;
+  trigger?: unknown[];
+  condition?: unknown[];
+  action?: unknown[];
+}
+
+export function parseAutomation(content: string): Automation {
+  return yaml.load(content) as Automation;
+}
+
+export function automationToMermaid(a: Automation): string {
+  const t = a.trigger ?? [];
+  const c = a.condition ?? [];
+  const act = a.action ?? [];
+  const lines: string[] = ['flowchart TD'];
+
+  lines.push('start([Start])');
+  if (t.length) {
+    lines.push('start --> trig');
+    lines.push('trig>Trigger]:::trigger');
+  } else {
+    lines.push('start --> cond');
+  }
+
+  if (t.length) lines.push('trig --> cond');
+  if (c.length) {
+    lines.push('cond{Condition}:::condition');
+  } else {
+    lines.push('cond --> act');
+  }
+
+  if (c.length) lines.push('cond -->|true| act');
+  lines.push('act>Action]:::action');
+  lines.push('act --> end([End])');
+
+  return lines.join('\n');
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'media',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{"path":"./tsconfig.node.json"}]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/ha-automation-visualizer/',
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize React + Vite + TS project
- setup Tailwind CSS and mermaid
- parse YAML automations from `public/automations`
- render list and diagram viewer
- provide example `licht_abends.yaml`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416aac00fc83289b6d5d99ce541cfc