### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ npm run dev
    ```bash
    npm run deploy
    ```
+3. Teste das gebaute Projekt lokal, um sicherzustellen, dass alle Pfade korrekt sind:
+   ```bash
+   npx serve dist
+   ```
 
 GitHub Pages kann anschließend aus dem Branch `gh-pages` die statische Seite
 hosten.

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     <div id="root"></div>
-    <script type="module" src="./src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update the entry script to use an absolute path so Vite can rewrite it when building
- document how to locally test the built output

## Testing
- `npm run build` *(fails: vite not found)*
- `npx serve dist` *(fails: 403 Forbidden for serve)*

------
https://chatgpt.com/codex/tasks/task_e_684170b16e188328b1e749a3bac37b8e