### PR TITLE
Fix parseAutomation bug and add agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+## Build Check
+After making changes to the repository, run `npm run build` to ensure the TypeScript sources compile successfully.
+
+## Code Style
+- Use TypeScript for all source files under `src/`.
+- Use 2 spaces for indentation.
+- Prefer functional React components.

--- a/src/utils/parseYaml.ts
+++ b/src/utils/parseYaml.ts
@@ -9,7 +9,8 @@ export interface Automation {
 }
 
 export function parseAutomation(content: string): Automation {
-  return yaml.load(content) as Automation;
+  const data = yaml.load(content) as Automation | undefined;
+  return data ?? {};
 }
 
 export function automationToMermaid(a: Automation): string {


### PR DESCRIPTION
## Summary
- prevent TypeError when parsing empty YAML
- add AGENTS.md with build and style instructions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684187a962c48328ba2581df1dfffea3