### PR TITLE
Fix mermaid rendering in DiagramRenderer

### DIFF
--- a/src/components/DiagramRenderer.tsx
+++ b/src/components/DiagramRenderer.tsx
@@ -11,9 +11,12 @@ export default function DiagramRenderer({ definition }: Props) {
   useEffect(() => {
     if (!ref.current) return;
     mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
-    mermaid.render('diagram', definition).then(({ svg }) => {
-      if (ref.current) ref.current.innerHTML = svg;
-    });
+    const id = `diagram-${Math.random().toString(36).slice(2)}`;
+    mermaid
+      .render(id, definition, ref.current)
+      .catch((err) => {
+        console.error(err);
+      });
   }, [definition]);
 
   return <div ref={ref} className="mermaid" />;


### PR DESCRIPTION
## Summary
- ensure mermaid diagrams use a unique id when rendered
- attach the diagram directly to the container element

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418f683f188328a3b1fe4f98569581