### PR TITLE
Fix reserved node id in mermaid diagram

### DIFF
--- a/src/utils/parseYaml.ts
+++ b/src/utils/parseYaml.ts
@@ -34,7 +34,7 @@ export function automationToMermaid(a: Automation): string {
     lines.push('cond --> act[Action]:::action');
   }
 
-  lines.push('act --> end([End])');
+  lines.push('act --> finish([End])');
 
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- fix a parsing error by avoiding the reserved `end` node in generated Mermaid definitions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684192962c28832883b5ed4fb3f91e67