### PR TITLE
Fix mermaid import

### DIFF
--- a/src/components/DiagramRenderer.tsx
+++ b/src/components/DiagramRenderer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import mermaid from 'mermaid';
+import mermaid from 'mermaid/dist/mermaid.esm.mjs';
 
 interface Props {
   definition: string;


### PR DESCRIPTION
## Summary
- adjust import path for mermaid to ensure browser version is bundled

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841956052b48328b1582f972e7d89b7