### PR TITLE
Fix mermaid parsing

### DIFF
--- a/src/utils/parseYaml.ts
+++ b/src/utils/parseYaml.ts
@@ -41,7 +41,11 @@ function summarizeAction(a: unknown): string {
 }
 
 function esc(text: string): string {
-  return text.replace(/"/g, '\\"')
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
 }
 
 export function automationToMermaid(a: Automation): string {


### PR DESCRIPTION
## Summary
- escape square brackets in Mermaid labels to avoid syntax errors

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684199eddfd883289cb55ca7be5765cc