### PR TITLE
Improve styling and transitions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,7 @@
 body {
-  @apply bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
+  @apply bg-blue-950 text-gray-100;
+}
+
+a {
+  @apply text-yellow-400 hover:text-yellow-300;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,8 @@ export default function App() {
 
   return (
     <div className="container mx-auto p-4">
-      <header className="mb-4 flex justify-between items-center border-b pb-2">
-        <a href="/" className="text-xl font-bold no-underline">
+      <header className="mb-4 flex justify-between items-center border-b border-yellow-600 pb-2">
+        <a href="/" className="text-xl font-bold no-underline text-yellow-400">
           HA YAML Visualizer
         </a>
         <span>
@@ -22,12 +22,21 @@ export default function App() {
           </a>
         </span>
       </header>
-      {!selected ? (
-        <AutomationList onSelect={setSelected} />
-      ) : (
-        <AutomationViewer info={selected} onBack={() => setSelected(null)} />
-      )}
-      <footer className="text-sm mt-8 border-t pt-4 text-center opacity-80">
+      <div className="relative min-h-[200px]">
+        <div
+          className={`transition-opacity duration-500 ${selected ? 'opacity-0 pointer-events-none absolute inset-0' : 'opacity-100'}`}
+        >
+          <AutomationList onSelect={setSelected} />
+        </div>
+        <div
+          className={`transition-opacity duration-500 ${selected ? 'opacity-100' : 'opacity-0 pointer-events-none absolute inset-0'}`}
+        >
+          {selected && (
+            <AutomationViewer info={selected} onBack={() => setSelected(null)} />
+          )}
+        </div>
+      </div>
+      <footer className="text-sm mt-8 border-t border-yellow-600 pt-4 text-center opacity-80">
         Beim mit * gekennzeichneten Link handelt es sich um einen Affiliate-Link.
         Ich erhalte eine Provision, für Dich entstehen keine Mehrkosten.
       </footer>

--- a/src/components/AutomationList.tsx
+++ b/src/components/AutomationList.tsx
@@ -43,7 +43,7 @@ export default function AutomationList({ onSelect }: Props) {
             {items.map((item) => (
               <li
                 key={item.file}
-                className="p-4 border rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="p-4 border border-blue-800 rounded cursor-pointer hover:bg-blue-800 hover:border-yellow-500 transition-colors"
                 onClick={() => onSelect(item)}
               >
                 <h3 className="text-lg font-medium">{item.title}</h3>

--- a/src/components/AutomationViewer.tsx
+++ b/src/components/AutomationViewer.tsx
@@ -22,7 +22,7 @@ export default function AutomationViewer({ info, onBack }: Props) {
 
   return (
     <div className="space-y-4">
-      <button onClick={onBack} className="underline">Zurück</button>
+      <button onClick={onBack} className="underline text-yellow-400 hover:text-yellow-300">Zurück</button>
       <h2 className="text-xl font-bold">{info.title}</h2>
       {(info.description || info.affiliate) && (
         <div className="md:flex md:items-center md:justify-between">
@@ -35,7 +35,7 @@ export default function AutomationViewer({ info, onBack }: Props) {
                 href={info.affiliate}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-block bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700"
+                className="inline-block bg-yellow-500 text-blue-900 px-4 py-2 rounded-md hover:bg-yellow-400"
               >
                 Jetzt Produkt entdecken
               </a>


### PR DESCRIPTION
## Summary
- refresh global styles with dark blue background and gold accents
- add fade transition when switching to an automation
- style headers and buttons with gold highlight
- tweak automation list item hover colors

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf6fe190832885b52dad04a50213