### PR TITLE
Adjust layout and styling

### DIFF
--- a/src/components/AutomationList.tsx
+++ b/src/components/AutomationList.tsx
@@ -43,7 +43,7 @@ export default function AutomationList({ onSelect }: Props) {
             {items.map((item) => (
               <li
                 key={item.file}
-                className="p-4 border border-blue-800 rounded cursor-pointer hover:bg-blue-800 hover:border-yellow-500 transition-colors"
+                className="p-4 border border-blue-800 rounded cursor-pointer hover:bg-blue-900 hover:border-yellow-500 transition-colors"
                 onClick={() => onSelect(item)}
               >
                 <h3 className="text-lg font-medium">{item.title}</h3>

--- a/src/components/AutomationViewer.tsx
+++ b/src/components/AutomationViewer.tsx
@@ -22,8 +22,16 @@ export default function AutomationViewer({ info, onBack }: Props) {
 
   return (
     <div className="space-y-4">
-      <button onClick={onBack} className="underline text-yellow-400 hover:text-yellow-300">Zurück</button>
-      <h2 className="text-xl font-bold">{info.title}</h2>
+      <div className="flex items-center space-x-2">
+        <button
+          onClick={onBack}
+          className="text-yellow-400 hover:text-yellow-300"
+          aria-label="Zurück"
+        >
+          &larr;
+        </button>
+        <h2 className="text-xl font-bold">{info.title}</h2>
+      </div>
       {(info.description || info.affiliate) && (
         <div className="md:flex md:items-center md:justify-between">
           {info.description && (

--- a/src/utils/parseYaml.ts
+++ b/src/utils/parseYaml.ts
@@ -89,7 +89,7 @@ export function automationToMermaid(a: Automation): string {
   const t = a.trigger ?? []
   const c = a.condition ?? []
   const act = a.action ?? []
-  const lines: string[] = ['flowchart TD']
+  const lines: string[] = ['flowchart LR']
 
   lines.push('classDef trigger fill:#FEF3C7')
   lines.push('classDef condition fill:#DBEAFE')


### PR DESCRIPTION
## Summary
- change flowchart orientation to left-to-right
- tweak hover color for automation items
- move back button next to heading in automation viewer

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d20a62208328b0ea303e2f949b21