### PR TITLE
Improve mobile YAML readability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,6 @@
 body {
-  @apply bg-blue-950 text-gray-100;
+  @apply text-gray-100;
+  background-color: #020c1b;
 }
 
 a {

--- a/src/components/AutomationViewer.tsx
+++ b/src/components/AutomationViewer.tsx
@@ -52,7 +52,7 @@ export default function AutomationViewer({ info, onBack }: Props) {
           )}
         </div>
       )}
-      <pre className="bg-gray-200 dark:bg-gray-800 p-4 overflow-auto">
+      <pre className="bg-black text-white p-4 overflow-auto">
         <code>{yamlText}</code>
       </pre>
       <DiagramRenderer definition={mermaidDef} />

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,9 @@
 .mermaid .action rect {
   fill: #93c5fd;
 }
+
+/* Allow diagrams to be larger than the screen width so they don't shrink on
+   mobile devices. */
+.mermaid svg {
+  max-width: none;
+}


### PR DESCRIPTION
## Summary
- darken base background to deep blue
- show YAML on black background with white text
- let Mermaid diagrams be larger on small screens

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec098f1c8328a0bd09cea0147b5b