### PR TITLE
Add direct URLs for each automation

### DIFF
--- a/src/components/AutomationList.tsx
+++ b/src/components/AutomationList.tsx
@@ -45,15 +45,20 @@ export default function AutomationList({ onSelect }: Props) {
           <h2 className="text-xl font-semibold mb-2">{cat}</h2>
           <ul className="space-y-2">
             {items.map((item) => (
-              <li
-                key={item.file}
-                className="p-4 border border-blue-800 rounded cursor-pointer hover:bg-blue-900 hover:border-yellow-500 transition-colors"
-                onClick={() => onSelect(item)}
-              >
-                <h3 className="text-lg font-medium">{item.title}</h3>
-                {item.description && (
-                  <p className="text-sm opacity-80">{item.description}</p>
-                )}
+              <li key={item.file}>
+                <a
+                  href={`?automation=${encodeURIComponent(item.file)}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    onSelect(item);
+                  }}
+                  className="block p-4 border border-blue-800 rounded cursor-pointer hover:bg-blue-900 hover:border-yellow-500 transition-colors no-underline"
+                >
+                  <h3 className="text-lg font-medium">{item.title}</h3>
+                  {item.description && (
+                    <p className="text-sm opacity-80">{item.description}</p>
+                  )}
+                </a>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- link each automation to a unique URL
- parse the `automation` query parameter and show the requested automation

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f0cc6654832899d7f51e929fd4a0